### PR TITLE
Handle case of traffic_allocation being None

### DIFF
--- a/splitio/splits.py
+++ b/splitio/splits.py
@@ -76,7 +76,9 @@ class Split(object):
         self._change_number = change_number
         self._conditions = conditions if conditions is not None else []
 
-        if traffic_allocation >= 0 and traffic_allocation <= 100:
+        if traffic_allocation is None:
+            self._traffic_allocation = 100
+        elif traffic_allocation >= 0 and traffic_allocation <= 100:
             self._traffic_allocation = traffic_allocation
         else:
             self._traffic_allocation = 100


### PR DESCRIPTION
In Python 3 you cannot compare None with an integer. As a result, the localhost
implementation fails.