### PR TITLE
[HOTFIX] - reschedule fetcher threads when connection fails

### DIFF
--- a/splitio/splits.py
+++ b/splitio/splits.py
@@ -437,7 +437,15 @@ class SelfRefreshingSplitFetcher(InMemorySplitFetcher):
                     response = self._split_change_fetcher.fetch(
                         self._change_number)
 
-                    if self._change_number >= response['till']:
+
+                    # If the response fails, and doesn't return a dict, or
+                    # returns a dict without the 'till' attribute, abort this
+                    # execution.
+                    if (
+                        not isinstance(response, dict)
+                        or 'till' not in response
+                        or self._change_number >= response['till']
+                    ):
                         return
 
                     if 'splits' in response and len(response['splits']) > 0:
@@ -475,6 +483,10 @@ class SelfRefreshingSplitFetcher(InMemorySplitFetcher):
         Timer thread
         """
         if self._stopped:
+            self._logger.error('Previous fetch failed, skipping this iteration '
+                               'and rescheduling segment refresh.')
+            self._stopped = False
+            self._timer_start()
             return
 
         try:

--- a/splitio/tests/test_segments.py
+++ b/splitio/tests/test_segments.py
@@ -298,7 +298,7 @@ class SelfRefreshingSegmentTimerRefreshTests(TestCase, MockUtilsMixin):
         self.segment._stopped = True
         self.segment._timer_refresh()
 
-        self.timer_mock.assert_not_called()
+        self.timer_mock.assert_called()
 
 
 class SegmentChangeFetcherTests(TestCase, MockUtilsMixin):

--- a/splitio/tests/test_splits.py
+++ b/splitio/tests/test_splits.py
@@ -310,7 +310,7 @@ class SelfRefreshingSplitFetcherTimerRefreshTests(TestCase, MockUtilsMixin):
         """Tests that _timer_refresh doesn't call start_tiemer if it is stopped"""
         self.fetcher.stopped = True
         self.fetcher._timer_refresh()
-        self.timer_start_mock.assert_not_called()
+        self.timer_start_mock.assert_called()
 
     def test_timer_start_called_if_thread_raises_exception(self):
         """


### PR DESCRIPTION
When an invalid response is received, instead of stopping fetcher threads, reschedule them with a timer