### PR TITLE
Set traffic allocation to 100 by default

### DIFF
--- a/splitio/splits.py
+++ b/splitio/splits.py
@@ -77,7 +77,9 @@ class Split(object):
         self._change_number = change_number
         self._conditions = conditions if conditions is not None else []
 
-        if traffic_allocation >= 0 and traffic_allocation <= 100:
+        if traffic_allocation is None:
+            self._traffic_allocation = 100
+        elif traffic_allocation >= 0 and traffic_allocation <= 100:
             self._traffic_allocation = traffic_allocation
         else:
             self._traffic_allocation = 100

--- a/splitio/tests/test_splits.py
+++ b/splitio/tests/test_splits.py
@@ -1073,6 +1073,13 @@ class TrafficAllocationTests(TestCase):
         )
         self.assertEqual(treatment1, 'on')
 
+        # Make sure traffic allocation is set to 100 at construction time if a
+        # value is not provided.
+        self.assertEqual(
+            self._splitObjects['whitelist'].traffic_allocation,
+            100
+        )
+
         treatment2, label1 = self._client._get_treatment_for_split(
             self._splitObjects['rollout1'], 'testKey', None
         )


### PR DESCRIPTION
Traffic allocation should be set to 100 if the value is not provided by the split.
Added a simple unit test to verify the behavior as well.