### PR TITLE
Feaure/impressions listener

### DIFF
--- a/splitio/factories.py
+++ b/splitio/factories.py
@@ -103,6 +103,7 @@ class LocalhostSplitFactory(SplitFactory):
         """
         return self._manager
 
+
 def get_factory(api_key, **kwargs):
     """
     :param api_key:

--- a/splitio/impressions.py
+++ b/splitio/impressions.py
@@ -63,7 +63,7 @@ def _notify_listener(listener, impressions_data):
     """
     if six.callable(listener):
         try:
-            listener(impressions_data)
+            listener({'impressions': impressions_data})
         except Exception:
             logging.getLogger('Impressions-Listener').exception(
                 'Exception caught when executing user provided impression '

--- a/splitio/impressions.py
+++ b/splitio/impressions.py
@@ -63,7 +63,7 @@ def _notify_listener(listener, impressions_data):
     """
     if six.callable(listener):
         try:
-            listener({'impressions': impressions_data})
+            listener(impressions_data)
         except Exception:
             logging.getLogger('Impressions-Listener').exception(
                 'Exception caught when executing user provided impression '

--- a/splitio/tasks.py
+++ b/splitio/tasks.py
@@ -5,7 +5,7 @@ import logging
 
 from .splits import Status
 from .impressions import build_impressions_data
-
+from .impressions import _notify_listener
 _logger = logging.getLogger(__name__)
 
 
@@ -111,7 +111,7 @@ def update_splits(split_cache, split_change_fetcher, split_parser):
         split_cache.disable()
 
 
-def report_impressions(impressions_cache, sdk_api):
+def report_impressions(impressions_cache, sdk_api, listener=None):
     """If the reporting process is enabled (through the impressions cache), this function collects
     the impressions from the cache and sends them to Split through the events API. If the process
     fails, no exceptions are raised (but they are logged) and the process is disabled.
@@ -121,6 +121,7 @@ def report_impressions(impressions_cache, sdk_api):
             return
 
         impressions = impressions_cache.fetch_all_and_clear()
+        _notify_listener(listener, impressions)
         test_impressions_data = build_impressions_data(impressions)
 
         _logger.debug('Impressions to send: %s' % test_impressions_data)

--- a/splitio/tasks.py
+++ b/splitio/tasks.py
@@ -122,7 +122,7 @@ def report_impressions(impressions_cache, sdk_api, listener=None):
 
         impressions = impressions_cache.fetch_all_and_clear()
         test_impressions_data = build_impressions_data(impressions)
-        _notify_listener(listener, test_impressions_data)
+        _notify_listener(listener, {'impressions': test_impressions_data})
 
         _logger.debug('Impressions to send: %s' % test_impressions_data)
 

--- a/splitio/tasks.py
+++ b/splitio/tasks.py
@@ -121,8 +121,8 @@ def report_impressions(impressions_cache, sdk_api, listener=None):
             return
 
         impressions = impressions_cache.fetch_all_and_clear()
-        _notify_listener(listener, impressions)
         test_impressions_data = build_impressions_data(impressions)
+        _notify_listener(listener, test_impressions_data)
 
         _logger.debug('Impressions to send: %s' % test_impressions_data)
 

--- a/splitio/tests/test_clients.py
+++ b/splitio/tests/test_clients.py
@@ -433,8 +433,11 @@ class SelfRefreshingBrokerBuildTreatmentLogTests(TestCase, MockUtilsMixin):
     def test_calls_self_updating_treatment_log_constructor(self):
         """Tests that _build_treatment_log calls SelfUpdatingTreatmentLog constructor"""
         self.self_updating_treatment_log_mock.assert_called_once_with(
-            self.client._sdk_api, max_count=self.client._max_impressions_log_size,
-            interval=self.client._impressions_interval)
+            self.client._sdk_api,
+            max_count=self.client._max_impressions_log_size,
+            interval=self.client._impressions_interval,
+            listener=None
+        )
 
     def test_calls_async_treatment_log_constructor(self):
         """Tests that _build_treatment_log calls AsyncTreatmentLog constructor"""

--- a/splitio/tests/test_impressions.py
+++ b/splitio/tests/test_impressions.py
@@ -536,12 +536,19 @@ class TestImpressionListener(TestCase):
 
     def test_uwsgi_impression_listener(self):
         impressions_cache = mock.MagicMock()
-        impressions_cache.fetch_all_and_clear.return_value = [1, 2, 3]
+        impressions = {
+            'testName': 'someTest',
+            'keyImpressions': [1, 2, 3]
+        }
+
+        impressions_cache.fetch_all_and_clear.return_value = {
+            'someTest': [1, 2, 3]
+        }
         some_api = mock.MagicMock()
         listener = mock.MagicMock()
         with mock.patch(
-            'splitio.impressions.build_impressions_data',
-            return_value=[1, 2, 3]
+            'splitio.tasks.build_impressions_data',
+            return_value=impressions
         ):
             report_impressions(
                 impressions_cache,
@@ -549,6 +556,4 @@ class TestImpressionListener(TestCase):
                 listener=listener
             )
 
-        listener.assert_called_with([1, 2, 3])
-
-
+        listener.assert_called_with(impressions)

--- a/splitio/tests/test_impressions.py
+++ b/splitio/tests/test_impressions.py
@@ -556,4 +556,4 @@ class TestImpressionListener(TestCase):
                 listener=listener
             )
 
-        listener.assert_called_with(impressions)
+        listener.assert_called_with({'impressions': impressions})

--- a/splitio/tests/test_impressions.py
+++ b/splitio/tests/test_impressions.py
@@ -16,6 +16,8 @@ from splitio.impressions import (Impression, build_impressions_data, TreatmentLo
                                  AsyncTreatmentLog)
 from splitio.tests.utils import MockUtilsMixin
 
+from splitio.tasks import report_impressions
+
 
 class BuildImpressionsDataTests(TestCase):
     def setUp(self):
@@ -512,3 +514,41 @@ class AsyncTreatmentLogTests(TestCase, MockUtilsMixin):
         # try:
         # except:
         #     self.fail('Unexpected exception raised')
+
+
+class TestImpressionListener(TestCase):
+    """
+    Tests for impression listener in "in-memory" and "uwsgi-cache" operation
+    modes
+    """
+
+    def test_inmemory_impression_listener(self):
+        some_api = mock.MagicMock()
+        listener = mock.MagicMock()
+        treatment_log = SelfUpdatingTreatmentLog(some_api, listener=listener)
+        with mock.patch(
+            'splitio.impressions.build_impressions_data',
+            return_value=[1, 2, 3]
+        ):
+            treatment_log._update_evictions('some_feature', [])
+
+        listener.assert_called_once_with([1, 2, 3])
+
+    def test_uwsgi_impression_listener(self):
+        impressions_cache = mock.MagicMock()
+        impressions_cache.fetch_all_and_clear.return_value = [1, 2, 3]
+        some_api = mock.MagicMock()
+        listener = mock.MagicMock()
+        with mock.patch(
+            'splitio.impressions.build_impressions_data',
+            return_value=[1, 2, 3]
+        ):
+            report_impressions(
+                impressions_cache,
+                some_api,
+                listener=listener
+            )
+
+        listener.assert_called_with([1, 2, 3])
+
+

--- a/splitio/uwsgi.py
+++ b/splitio/uwsgi.py
@@ -101,7 +101,7 @@ def uwsgi_update_segments(user_config):
         _logger.exception('Exception caught updating segments')
 
 
-def uwsgi_report_impressions(user_config, listener=None):
+def uwsgi_report_impressions(user_config):
     try:
         config = _get_config(user_config)
         seconds = config['impressionsRefreshRate']

--- a/splitio/uwsgi.py
+++ b/splitio/uwsgi.py
@@ -101,14 +101,17 @@ def uwsgi_update_segments(user_config):
         _logger.exception('Exception caught updating segments')
 
 
-def uwsgi_report_impressions(user_config):
+def uwsgi_report_impressions(user_config, listener=None):
     try:
         config = _get_config(user_config)
         seconds = config['impressionsRefreshRate']
         while True:
             impressions_cache = UWSGIImpressionsCache(get_uwsgi())
             sdk_api = api_factory(config)
-            report_impressions(impressions_cache, sdk_api)
+            report_impressions(
+                impressions_cache,
+                sdk_api,
+                user_config.get('impression_listener'))
 
             time.sleep(seconds)
     except:


### PR DESCRIPTION
Impression Listener for in-memory and uwsgi-cache operation modes of the Python sdk.

For in-memory, an extra keyword argument 'impression_listener" should be passed to `get_factory()`.

For uwsgi, an `impression_listener` key should be present in the user_config dict passed to the threads.

In both cases the handler should be a callable object ready to accept an object with impressions grouped by feature name.