### PR TITLE
Fix installs on Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,19 +3,24 @@
 
 from setuptools import setup, find_packages
 from os import path
-from sys import version_info
 
-tests_require = ['flake8', 'pytest', 'pytest-mock', 'coverage', 'pytest-cov']
+tests_require = [
+    'flake8',
+    'pytest',
+    'pytest-mock',
+    'coverage',
+    'pytest-cov',
+    'mock;python_version<"3"'
+]
 install_requires = [
     'requests>=2.9.1',
     'pyyaml>=5.1',
     'future>=0.15.2',
     'docopt>=0.6.2',
+    'enum34;python_version<"3.4"',
+    'six>=1.10.0;python_version<"3"',
+    'futures>=3.0.5;python_version<"3"'
 ]
-
-if version_info < (3,):
-    tests_require += ['mock']
-    install_requires += ['six>=1.10.0', 'futures>=3.0.5', 'enum34>=1.1.5']
 
 with open(path.join(path.abspath(path.dirname(__file__)),
                     'splitio', 'version.py')) as f:


### PR DESCRIPTION
Fixes #166 

```sh
pip list
Package        Version    Location                  
-------------- ---------- --------------------------
asd            0          /home/sam/tmp/splitpy3test
certifi        2019.11.28 
cffi           1.13.2     
chardet        3.0.4      
docopt         0.6.2      
future         0.18.2     
idna           2.8        
mmh3cffi       0.1.4      
pip            18.1       
pycparser      2.19       
PyYAML         5.3        
requests       2.22.0     
setuptools     45.0.0     
splitio-client 8.1.7b1    
urllib3        1.25.7     
wheel          0.33.6     
```