### PR TITLE
Make block_until_ready() guarantee factory readiness

### DIFF
--- a/splitio/client/factory.py
+++ b/splitio/client/factory.py
@@ -108,16 +108,11 @@ class SplitFactory(object):  # pylint: disable=too-many-instance-attributes
         if self._sdk_ready_flag is not None:
             self._status = Status.NOT_INITIALIZED
             # add a listener that updates the status to READY once the flag is set.
-            ready_updater = threading.Thread(target=self._update_status_when_ready)
+            ready_updater = threading.Thread(target=self.block_until_ready)
             ready_updater.setDaemon(True)
             ready_updater.start()
         else:
             self._status = Status.READY
-
-    def _update_status_when_ready(self):
-        """Wait until the sdk is ready and update the status."""
-        self._sdk_ready_flag.wait()
-        self._status = Status.READY
 
     def _get_storage(self, name):
         """
@@ -152,6 +147,7 @@ class SplitFactory(object):  # pylint: disable=too-many-instance-attributes
     def block_until_ready(self, timeout=None):
         """
         Blocks until the sdk is ready or the timeout specified by the user expires.
+        When ready, the factory's status is updated accordingly.
 
         :param timeout: Number of seconds to wait (fractions allowed)
         :type timeout: int
@@ -161,6 +157,8 @@ class SplitFactory(object):  # pylint: disable=too-many-instance-attributes
 
             if not ready:
                 raise TimeoutException('SDK Initialization: time of %d exceeded' % timeout)
+
+            self._status = Status.READY
 
     @property
     def ready(self):

--- a/tests/client/test_factory.py
+++ b/tests/client/test_factory.py
@@ -86,7 +86,6 @@ class SplitFactoryTests(object):
         assert factory._tasks['telemetry']._api == factory._apis['telemetry']
         assert factory._labels_enabled is True
         factory.block_until_ready()
-        time.sleep(1) # give a chance for the bg thread to set the ready status
         assert factory.ready
         factory.destroy()
 
@@ -164,7 +163,6 @@ class SplitFactoryTests(object):
         assert factory._labels_enabled is False
         assert isinstance(factory._impression_listener, ImpressionListenerWrapper)
         factory.block_until_ready()
-        time.sleep(1) # give a chance for the bg thread to set the ready status
         assert factory.ready
         factory.destroy()
 
@@ -182,7 +180,6 @@ class SplitFactoryTests(object):
         assert factory._labels_enabled is True
         assert factory._impression_listener is None
         factory.block_until_ready()
-        time.sleep(1) # give a chance for the bg thread to set the ready status
         assert factory.ready
         factory.destroy()
 
@@ -233,7 +230,6 @@ class SplitFactoryTests(object):
         # Start factory and make assertions
         factory = get_factory('some_api_key')
         factory.block_until_ready()
-        time.sleep(1) # give a chance for the bg thread to set the ready status
         assert factory.ready
         assert factory.destroyed is False
 
@@ -303,7 +299,6 @@ class SplitFactoryTests(object):
         assert factory.destroyed is False
 
         factory.block_until_ready()
-        time.sleep(1) # give a chance for the bg thread to set the ready status
         assert factory.ready
 
         event = threading.Event()

--- a/tests/integration/test_client_e2e.py
+++ b/tests/integration/test_client_e2e.py
@@ -578,7 +578,6 @@ class LocalhostIntegrationTests(object):  #pylint: disable=too-few-public-method
         filename = os.path.join(os.path.dirname(__file__), 'files', 'file2.yaml')
         factory = get_factory('localhost', config={'splitFile': filename})
         factory.block_until_ready()
-        time.sleep(1)
         client = factory.client()
         assert client.get_treatment_with_config('key', 'my_feature') == ('on', '{"desc" : "this applies only to ON treatment"}')
         assert client.get_treatment_with_config('only_key', 'my_feature') == (


### PR DESCRIPTION
# Python SDK

## What did you accomplish?
The code change introduced in this PR ensures that a factory is ready when `block_until_ready` returns. Prior to this change, the value of `factory.ready` was not guaranteed to be `True` after `block_until_ready()` returns, which is counterintuitive. This behavior was due to the non-deterministic nature of Python thread scheduling.

## How do we test the changes introduced in this PR?
This change can be tested by running the test suite. I simply removed the `time.sleep(1)` calls that enabled factory readiness assertions to pass before this change. 

## Extra Notes